### PR TITLE
docs: install docs extra_requires

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -30,3 +30,10 @@ sphinx:
 # python:
 #    install:
 #    - requirements: docs/requirements.txt
+
+python:
+  install:
+    - method: pip
+      path: django-kitamanager
+      extra_requirements:
+        - docs


### PR DESCRIPTION
This should fix the missing theme when trying to build:

no theme named 'sphinx_rtd_theme' found (missing theme.conf?)