### PR TITLE
fix: correctly calculate valid pay tags for children

### DIFF
--- a/django-kitamanager/kitamanager/admin/child.py
+++ b/django-kitamanager/kitamanager/admin/child.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ValidationError
 from django.forms import ModelForm
 from kitamanager.models import (
     ChildContract,
+    ChildPaymentTable,
     Area,
 )
 
@@ -20,9 +21,10 @@ class ChildContractForm(ModelForm):
 
     def clean_pay_tags(self):
         # make sure only tags from the selected pay_plan for the given date are used
-        childpayment_tables = self.cleaned_data["pay_plan"].tables.filter(
-            start__lte=self.cleaned_data["start"], end__gt=self.cleaned_data["end"]
-        )
+
+        childpayment_tables = ChildPaymentTable.objects.by_daterange(
+            self.cleaned_data["start"], self.cleaned_data["end"]
+        ).filter(plan=self.cleaned_data["pay_plan"])
         valid_tags = set()
         for cpt in childpayment_tables:
             for e in list(cpt.entries.values_list("name", flat=True)):

--- a/django-kitamanager/kitamanager/models/child_payment.py
+++ b/django-kitamanager/kitamanager/models/child_payment.py
@@ -1,3 +1,4 @@
+import datetime
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from django.contrib.postgres.fields import RangeOperators, RangeBoundary
@@ -29,6 +30,23 @@ class ChildPaymentPlan(models.Model):
         return reverse("kitamanager:childpayment-detail", args=[self.pk])
 
 
+class ChildPaymentTableManager(models.Manager):
+    """
+    Custom Manager for the ChildPaymentTable model
+    """
+
+    def by_daterange(self, start: datetime.date, end: datetime.date):
+        """
+        Filter tables for the plan by date range
+        :param start: the start date (included in the result)
+        :type start: datetime.date
+        :param end: the end date (excluded in the result)
+        :type end: datetime.date
+
+        """
+        return self.filter(start__lte=end, end__gt=start)
+
+
 class ChildPaymentTable(models.Model):
     """
     A ChildPaymentTable which is related to a single ChildPaymentPlan
@@ -41,6 +59,9 @@ class ChildPaymentTable(models.Model):
         max_digits=4, decimal_places=2, default=39.40, help_text=_("weekly working hours for full time")
     )
     comment = models.TextField(blank=True)
+
+    # default and custom managers
+    objects = ChildPaymentTableManager()
 
     def __str__(self):
         return f"{self.plan}: {self.start} - {self.end}"


### PR DESCRIPTION
It wasn't possible to save a ChildContract given that the valid pay tags was wrongly calculated.