### PR TITLE
fix: count child, team and mgmt hours when comparing requirements

### DIFF
--- a/django-kitamanager/kitamanager/templates/kitamanager/employee_statistics.html
+++ b/django-kitamanager/kitamanager/templates/kitamanager/employee_statistics.html
@@ -15,7 +15,7 @@
         </h5>
         <div class="notification is-info is-light">
           {% blocktranslate trimmed %}
-          Children requirements vs. Employee working hours. Only the child and team hours count for Employee working hours here.
+          Children requirements vs. Employee working hours. Only child, team and mgmt hours count for Employee working hours here.
           Eg. 10% means 110%. So everything over 0 is good.
           {% endblocktranslate %}
         </div>
@@ -31,7 +31,7 @@
         </h5>
         <div class="notification is-info is-light">
           {% blocktranslate trimmed %}
-          Children requirements vs. Employee working hours. Only the child and team hours count for Employee working hours here.
+          Children requirements vs. Employee working hours. Only child, team and mgmt hours count for Employee working hours here.
           {% endblocktranslate %}
         </div>
         <canvas id="statisticChildRequirementVsEmployeeHoursChart"></canvas>

--- a/django-kitamanager/kitamanager/views_statistic.py
+++ b/django-kitamanager/kitamanager/views_statistic.py
@@ -39,10 +39,12 @@ def statistic_charts_child_requirement_vs_employee_hours(request):
         # children requirements
         sum_requirements, sum_requirements_hours_per_week = ChildContract.objects.sum_requirements(current)
         datasets[0]["data"].append(sum_requirements_hours_per_week)
-        # employee working hours (child and team hours only)
+        # employee working hours (child + team hours + mgmt hours only)
         sum_hours = EmployeeContract.objects.sum_hours(current)
-        sum_hours_child_team = sum_hours["hours_child_sum"] + sum_hours["hours_team_sum"]
-        datasets[1]["data"].append(sum_hours_child_team)
+        sum_hours_child_team_mgmt = (
+            sum_hours["hours_child_sum"] + sum_hours["hours_team_sum"] + sum_hours["hours_management_sum"]
+        )
+        datasets[1]["data"].append(sum_hours_child_team_mgmt)
         current = current + relativedelta(months=1)
 
     return JsonResponse(
@@ -80,12 +82,14 @@ def statistic_charts_child_requirement_vs_employee_hours_percent(request):
         labels.append(current.strftime("%Y-%m"))
         # children requirements
         sum_requirements, sum_requirements_hours_per_week = ChildContract.objects.sum_requirements(current)
-        # employee working hours (child and team hours only)
+        # employee working hours (child + team + mgmt hours only)
         sum_hours = EmployeeContract.objects.sum_hours(current)
-        sum_hours_child_team = sum_hours["hours_child_sum"] + sum_hours["hours_team_sum"]
+        sum_hours_child_team_mgmt = (
+            sum_hours["hours_child_sum"] + sum_hours["hours_team_sum"] + sum_hours["hours_management_sum"]
+        )
         # in percent above/below 100%
         if sum_requirements_hours_per_week > 0:
-            x = (sum_hours_child_team / sum_requirements_hours_per_week * 100) - 100
+            x = (sum_hours_child_team_mgmt / sum_requirements_hours_per_week * 100) - 100
         else:
             x = 0
         datasets[0]["data"].append(x)


### PR DESCRIPTION
The comparing requiremnts (coming from the amount of children) and working hours (coming from employees), also count for mangagement hours (in addition to child and team hours).
That's how ISBJ seems to count the numbers.